### PR TITLE
Adjust DIR column justification and order (#80)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,15 @@
 	* Archive on replace/expire: old content is archived to
 	  `server/data/archive/` with metadata before removal. Nothing is
 	  ever permanently deleted.
+	* Directory column justification (#80): PRICE right-justified with
+	  leading space, LIFE right-justified with 2-space indent, VOTE
+	  indented by one space. No leading zeros.
+	* Column order changed to: PRICE, AUTHOR, VOTE, UPLDDATE, LIFE.
+	  LIFE moved to last position to fix ROM upload preview showing
+	  wrong column at "NEW ENTRY OK?" prompt (ROM uses last column
+	  for LIFE preview via $C001).
+* Dev:
+	* `vice_test.sh` updated to use CRT cartridge instead of D64.
 
 # 0.13.1-beta (2026-06-04)
 

--- a/server/compunet_server.py
+++ b/server/compunet_server.py
@@ -1845,14 +1845,15 @@ class CompunetSession:
                 data.extend(ascii_to_petscii(page_str + title_field))
                 data.append(0x2C)
                 # Column 1: PRICE (must be first — client checks this for SHOW)
-                price_str = '{:.2f}'.format(page.price) if page.price > 0 else ''
-                data.extend(ascii_to_petscii(price_str))
+                if page.price > 0:
+                    data.extend(ascii_to_petscii(' ' + '{:.2f}'.format(page.price).rjust(6)))
                 data.append(0x2C)
-                # Column 2: LIFE
-                data.extend(ascii_to_petscii(str(page.life)))
+                # Column 2: LIFE (right-justified, 2-space indent)
+                if page.life > 0:
+                    data.extend(ascii_to_petscii('  ' + str(page.life).rjust(3)))
                 data.append(0x2C)
                 # Column 3: VOTE
-                vote_str = str(page.vote) if page.vote > 0 else ''
+                vote_str = f' {page.vote}' if page.vote > 0 else ''
                 data.extend(ascii_to_petscii(vote_str))
                 data.append(0x2C)
                 # Column 4: PAGE
@@ -1995,13 +1996,13 @@ class CompunetSession:
         # F7/F8 cycles through them. $C002 selects which to display.
         data.extend(ascii_to_petscii(' PRICE'))
         data.append(0x2C)
-        data.extend(ascii_to_petscii(' LIFE'))
-        data.append(0x2C)
         data.extend(ascii_to_petscii(' AUTHOR'))
         data.append(0x2C)
         data.extend(ascii_to_petscii(' VOTE'))
         data.append(0x2C)
         data.extend(ascii_to_petscii('UPLDDATE'))
+        data.append(0x2C)
+        data.extend(ascii_to_petscii(' LIFE'))
         data.append(0x0D)
 
         # Separator byte consumed by L_A448's JSR L96CC (value unused)
@@ -2040,22 +2041,18 @@ class CompunetSession:
                 # Column 1: PRICE (0 if already purchased)
                 effective_price = 0 if child.page_num in self.purchased else child.price
                 if effective_price > 0:
-                    data.extend(ascii_to_petscii('{:.2f}'.format(effective_price)[:8]))
+                    data.extend(ascii_to_petscii(' ' + '{:.2f}'.format(effective_price).rjust(6)))
                 data.append(0x2C)
-                # Column 2: LIFE
-                if child.life > 0:
-                    data.extend(ascii_to_petscii(str(child.life)[:8]))
-                data.append(0x2C)
-                # Column 3: AUTHOR
+                # Column 2: AUTHOR
                 data.extend(ascii_to_petscii(child.author[:8]))
                 data.append(0x2C)
-                # Column 4: VOTE — "avg (count)" format
+                # Column 3: VOTE — "avg (count)" format
                 if child.vote > 0:
                     vote_count = self._get_vote_count(child.page_num)
-                    vote_str = f'{child.vote} ({vote_count})'
+                    vote_str = f' {child.vote} ({vote_count})'
                     data.extend(ascii_to_petscii(vote_str[:8]))
                 data.append(0x2C)
-                # Column 5: UPLOADED — "DD-MMM" format, hyphen-aligned
+                # Column 4: UPLOADED — "DD-MMM" format, hyphen-aligned
                 uploaded = getattr(child, 'uploaded', None)
                 if uploaded:
                     import datetime
@@ -2067,6 +2064,10 @@ class CompunetSession:
                         data.extend(ascii_to_petscii(date_str))
                     except (ValueError, AttributeError):
                         pass
+                data.append(0x2C)
+                # Column 5: LIFE (last — ROM uses $C001 for upload LIFE preview)
+                if child.life > 0:
+                    data.extend(ascii_to_petscii('  ' + str(child.life).rjust(3)))
                 data.append(0x0D)
         
         log.info('PAGE response: %d bytes hex=%s', len(data), data.hex())

--- a/server/terminal.py
+++ b/server/terminal.py
@@ -167,7 +167,7 @@ class TerminalSession:
         self.current_page = directory.root
         self.dir_cursor = 0
         self.dir_offset = 0
-        self.dir_column = 0         # 0=PRICE, 1=LIFE, 2=AUTHOR, 3=VOTE, 4=UPLDDATE
+        self.dir_column = 0         # 0=PRICE, 1=AUTHOR, 2=VOTE, 3=UPLDDATE, 4=LIFE
         self.mail_column = 0        # 0=SENDER, 1=DATE, 2=STATUS
         self.duck_pos = 0
         self.mode = 'login'         # login, directory, frame, mail
@@ -532,7 +532,7 @@ class TerminalSession:
         breadcrumb = f'  {page.page_num} {page.title}'
         await self.send_text(breadcrumb[:29].ljust(29))
         await self.send(self.B_THIN_V)
-        cols = [' PRICE', ' LIFE', ' AUTHOR', ' VOTE', 'UPLDDATE']
+        cols = [' PRICE', ' AUTHOR', ' VOTE', 'UPLDDATE', ' LIFE']
         await self.send_text(cols[self.dir_column].ljust(8)[:8])
         await self.send(self.B_THIN_V)
 
@@ -562,15 +562,15 @@ class TerminalSession:
                 content = f'{page_num_str:>5s} {title}{type_str}'[:29]
 
                 if self.dir_column == 0:
-                    col_val = '{:.2f}'.format(child.price) if child.price > 0 else ''
+                    col_val = ' ' + '{:.2f}'.format(child.price).rjust(6) if child.price > 0 else ''
                 elif self.dir_column == 1:
-                    col_val = str(child.life) if child.life > 0 else ''
-                elif self.dir_column == 2:
                     col_val = child.author[:8]
+                elif self.dir_column == 2:
+                    col_val = f' {child.vote}' if child.vote > 0 else ''
                 elif self.dir_column == 3:
-                    col_val = str(child.vote) if child.vote > 0 else ''
-                else:
                     col_val = self._format_upload_date(child)
+                else:
+                    col_val = '  ' + str(child.life).rjust(3) if child.life > 0 else ''
                 col_val = col_val[:8].ljust(8)
             else:
                 await self.send(COL_WHITE)
@@ -729,7 +729,7 @@ class TerminalSession:
         # Column header at row 8, col 31
         await self.cursor_to(8, 31)
         await self.send(COL_WHITE)
-        cols = [' PRICE', ' LIFE', ' AUTHOR', ' VOTE', 'UPLDDATE']
+        cols = [' PRICE', ' AUTHOR', ' VOTE', 'UPLDDATE', ' LIFE']
         await self.send_text(cols[self.dir_column].ljust(8)[:8])
 
         # Column values for each visible entry
@@ -740,15 +740,15 @@ class TerminalSession:
             if i < len(visible):
                 child = visible[i]
                 if self.dir_column == 0:
-                    col_val = '{:.2f}'.format(child.price) if child.price > 0 else ''
+                    col_val = ' ' + '{:.2f}'.format(child.price).rjust(6) if child.price > 0 else ''
                 elif self.dir_column == 1:
-                    col_val = str(child.life) if child.life > 0 else ''
-                elif self.dir_column == 2:
                     col_val = child.author[:8]
+                elif self.dir_column == 2:
+                    col_val = f' {child.vote}' if child.vote > 0 else ''
                 elif self.dir_column == 3:
-                    col_val = str(child.vote) if child.vote > 0 else ''
-                else:
                     col_val = self._format_upload_date(child)
+                else:
+                    col_val = '  ' + str(child.life).rjust(3) if child.life > 0 else ''
                 col_val = col_val[:8].ljust(8)
                 if i == self.dir_cursor:
                     await self.send(COL_WHITE)
@@ -777,15 +777,15 @@ class TerminalSession:
         content = f'{page_num_str:>5s} {title}{type_str}'[:29]
 
         if self.dir_column == 0:
-            col_val = '{:.2f}'.format(child.price) if child.price > 0 else ''
+            col_val = ' ' + '{:.2f}'.format(child.price).rjust(6) if child.price > 0 else ''
         elif self.dir_column == 1:
-            col_val = str(child.life) if child.life > 0 else ''
-        elif self.dir_column == 2:
             col_val = child.author[:8]
+        elif self.dir_column == 2:
+            col_val = f' {child.vote}' if child.vote > 0 else ''
         elif self.dir_column == 3:
-            col_val = str(child.vote) if child.vote > 0 else ''
-        else:
             col_val = self._format_upload_date(child)
+        else:
+            col_val = '  ' + str(child.life).rjust(3) if child.life > 0 else ''
         col_val = col_val[:8].ljust(8)
 
         if idx == self.dir_cursor:

--- a/vice_test.sh
+++ b/vice_test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Compunet Reborn — Automated VICE test launcher
-# Launches x64sc with the SFX client, injects keystrokes to automate login.
-# VICE autostart handles LOAD + RUN; this script sends CONNECT + credentials.
+# Launches x64sc with the CRT cartridge, injects keystrokes to automate login.
 # Leaves remote monitor open on port 6510 for debug sessions.
 #
 # Usage: ./vice_test.sh <username> <password> [--restart-server]
@@ -9,7 +8,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-D64="$SCRIPT_DIR/client/c64/compunet-reborn-live.d64"
+CRT="$SCRIPT_DIR/client/c64/compunet-reborn-live.crt"
 MONITOR_PORT=6510
 VICE=x64sc
 
@@ -36,13 +35,11 @@ PASSWORD="${args[1]}"
 
 # --- Preflight checks ---
 
-if [ ! -f "$D64" ]; then
-    echo "Error: D64 not found at $D64"
+if [ ! -f "$CRT" ]; then
+    echo "Error: CRT not found at $CRT"
     echo "Build it first: make -C client/c64/src/"
     exit 1
 fi
-
-PRG="$D64"
 
 if ! command -v "$VICE" &>/dev/null; then
     echo "Error: $VICE not found in PATH"
@@ -67,14 +64,13 @@ fi
 # --- Launch VICE ---
 
 echo "Launching $VICE with remote monitor on port $MONITOR_PORT..."
-echo "  D64:      $D64"
+echo "  CRT:      $CRT"
 echo "  Username: $USERNAME"
 
 $VICE \
     -remotemonitor \
     -remotemonitoraddress ip4://127.0.0.1:$MONITOR_PORT \
-    -8 "$D64" \
-    -autostart "$D64:compunet" &
+    -cartcrt "$CRT" &
 
 VICE_PID=$!
 echo "  VICE PID: $VICE_PID"
@@ -109,19 +105,14 @@ send_keybuf() {
 
 # --- Inject login sequence ---
 # All keystrokes sent via remote monitor for consistent behaviour.
-# Uses the live (auto-connect) D64 — no phone number needed.
+# CRT boots directly to Compunet BASIC — just type CONNECT.
 
-# Step 1: RUN (VICE autostart loads but doesn't RUN for ,8 loads)
-sleep 3
-echo "Sending: RUN"
-send_keybuf "RUN"
-
-# Step 2: Wait for decompression + CONNECT (auto-connect dials automatically)
-sleep 7
+# Step 1: CONNECT (CRT boots to Compunet prompt, auto-connect dials automatically)
+sleep 2
 echo "Sending: CONNECT"
 send_keybuf "CONNECT"
 
-# Step 3: Username (wait for LINKING + welcome screen)
+# Step 2: Username (wait for LINKING + welcome screen)
 sleep 8
 echo "Sending: $USERNAME"
 send_keybuf "$USERNAME"


### PR DESCRIPTION
- PRICE: right-justified with leading space
- LIFE: right-justified with 2-space indent, no leading zeros
- VOTE: indented by one space
- Column order: PRICE, AUTHOR, VOTE, UPLDDATE, LIFE (LIFE last — ROM upload preview uses $C001/last column for LIFE)
- vice_test.sh: use CRT cartridge instead of D64
- Both protocol and terminal clients updated