### PR TITLE
Fix download default filename missing first character (#83)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,10 @@
 	  LIFE moved to last position to fix ROM upload preview showing
 	  wrong column at "NEW ENTRY OK?" prompt (ROM uses last column
 	  for LIFE preview via $C001).
+	* Fixed: download default filename missing first character (#83).
+	  Title in directory entry was one byte too far left for the ROM's
+	  filename buffer copy. Shifted entry alignment: page number now
+	  rjust(6), title max 17 chars, breadcrumb indented to match.
 * Dev:
 	* `vice_test.sh` updated to use CRT cartridge instead of D64.
 

--- a/server/compunet_server.py
+++ b/server/compunet_server.py
@@ -1810,7 +1810,7 @@ class CompunetSession:
         data.append(0x00)
 
         # Part 4: breadcrumb
-        data.extend(ascii_to_petscii('    1 *** COMPUNET ***'))
+        data.extend(ascii_to_petscii('     1 *** COMPUNET ***'))
         data.append(0x0D)
         data.extend(ascii_to_petscii(f'  UPLOADS {self._ucat_offset+1}-{self._ucat_offset+len(visible)}'))
         data.append(0x00)
@@ -1839,9 +1839,9 @@ class CompunetSession:
             data.append(0x0D)
         else:
             for page in visible:
-                page_str = str(page.page_num).rjust(5) + ' '
+                page_str = str(page.page_num).rjust(6) + ' '
                 type_str = page.type_string().ljust(3)
-                title_field = page.title[:18].ljust(18) + type_str
+                title_field = page.title[:17].ljust(17) + type_str
                 data.extend(ascii_to_petscii(page_str + title_field))
                 data.append(0x2C)
                 # Column 1: PRICE (must be first — client checks this for SHOW)
@@ -1977,9 +1977,9 @@ class CompunetSession:
 
         # --- Part 4: Routing/breadcrumb (stored at $D400, displayed at row 7) ---
         # Shows current directory path inside the box, above entries.
-        data.extend(ascii_to_petscii('    1 *** COMPUNET ***'))
+        data.extend(ascii_to_petscii('     1 *** COMPUNET ***'))
         data.append(0x0D)
-        path_line2 = '  ' + str(page.page_num) + ' ' + (page.title or '')
+        path_line2 = '   ' + str(page.page_num) + ' ' + (page.title or '')
         data.extend(ascii_to_petscii(path_line2[:22].ljust(24)))
         # Unread mail indicator at column 25 (aligned with type field)
         mail_file = os.path.join(MAIL_DIR, self.user_id + '.json')
@@ -2032,10 +2032,10 @@ class CompunetSession:
                 # First 6 chars = page number (5 right-aligned + space)
                 # Then title left-aligned, type right-aligned (20 chars total)
                 # Type suffix must start at screen column 25 (SHOW reads $19)
-                page_str = str(child.page_num).rjust(5) + ' '
+                page_str = str(child.page_num).rjust(6) + ' '
                 type_str = child.type_string().ljust(3)
-                title = child.title[:18]
-                title_field = title.ljust(18) + type_str
+                title = child.title[:17]
+                title_field = title.ljust(17) + type_str
                 data.extend(ascii_to_petscii(page_str + title_field))
                 data.append(0x2C)
                 # Column 1: PRICE (0 if already purchased)
@@ -2133,7 +2133,7 @@ class CompunetSession:
         data.append(0x00)
 
         # Part 4: breadcrumb
-        data.extend(ascii_to_petscii('    1 *** COMPUNET ***'))
+        data.extend(ascii_to_petscii('     1 *** COMPUNET ***'))
         data.append(0x0D)
         data.extend(ascii_to_petscii('  WHO'))
         data.append(0x00)

--- a/server/terminal.py
+++ b/server/terminal.py
@@ -529,7 +529,7 @@ class TerminalSession:
         # Row 8: breadcrumb + column header
         await self.send(self.B_THICK_V)
         await self.send(COL_WHITE)
-        breadcrumb = f'  {page.page_num} {page.title}'
+        breadcrumb = f'   {page.page_num} {page.title}'
         await self.send_text(breadcrumb[:29].ljust(29))
         await self.send(self.B_THIN_V)
         cols = [' PRICE', ' AUTHOR', ' VOTE', 'UPLDDATE', ' LIFE']
@@ -557,9 +557,9 @@ class TerminalSession:
             elif i < len(visible):
                 child = visible[i]
                 page_num_str = str(child.page_num)
-                title = child.title[:18].ljust(18)
+                title = child.title[:17].ljust(17)
                 type_str = child.type_string()[:5].ljust(5)
-                content = f'{page_num_str:>5s} {title}{type_str}'[:29]
+                content = f'{page_num_str:>6s} {title}{type_str}'[:29]
 
                 if self.dir_column == 0:
                     col_val = ' ' + '{:.2f}'.format(child.price).rjust(6) if child.price > 0 else ''
@@ -772,9 +772,9 @@ class TerminalSession:
 
         child = visible[idx]
         page_num_str = str(child.page_num)
-        title = child.title[:18].ljust(18)
+        title = child.title[:17].ljust(17)
         type_str = child.type_string()[:5].ljust(5)
-        content = f'{page_num_str:>5s} {title}{type_str}'[:29]
+        content = f'{page_num_str:>6s} {title}{type_str}'[:29]
 
         if self.dir_column == 0:
             col_val = ' ' + '{:.2f}'.format(child.price).rjust(6) if child.price > 0 else ''
@@ -1792,7 +1792,7 @@ class TerminalSession:
             await self.set_charset("upper")
             await self.send(self.B_THICK_V)
             type_str = (page_type + str(lifetime) if page_type else '')[:5].ljust(5)
-            content = f'      {title[:18]:<18s}{type_str}'[:29]
+            content = f'       {title[:17]:<17s}{type_str}'[:29]
             await self.send_text(content)
             await self.set_charset("upper")
             await self.send(self.B_THIN_V)


### PR DESCRIPTION
The ROM's filename buffer copy reads the title from a fixed offset in the directory entry data. Our title was one byte too far left (offset 6 instead of 7). Shifted entry alignment:
- Page number: rjust(6) + 1 space (was rjust(5) + 1 space)
- Title: max 17 chars (was 18)
- Breadcrumb: extra leading space to match

Also applied to terminal client for consistency.