### PR TITLE
Fix UCAT LIFE extend and paging issues (#92)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,15 @@
+# 0.13.4-beta (2026-06-07)
+
+* Server:
+	* Fixed: LIFE extend in UCAT mode now targets the correct page (#92).
+	  Previously used the parent directory's children instead of the UCAT
+	  entries, causing extends to fail or hit the wrong page.
+	* Fixed: directory refresh after LIFE extend in UCAT no longer advances
+	  to the next page. Was showing "NO UPLOADS" because it treated the
+	  refresh as a MORE request.
+	* Fixed: pressing UCAT while already in UCAT now resets to page 1
+	  instead of advancing to the next page.
+
 # 0.13.3-beta (2026-06-06)
 
 * Server:

--- a/server/compunet_server.py
+++ b/server/compunet_server.py
@@ -786,7 +786,15 @@ class CompunetSession:
             log.info('P cmd: dir_displayed=%s params=%s (not entering subdir)',
                      self.dir_displayed, params.hex() if params else 'none')
         if getattr(self, '_ucat_active', False):
-            return self._cmd_ucat()
+            if params:
+                try:
+                    selected = int(params.decode('ascii'))
+                except (ValueError, UnicodeDecodeError):
+                    selected = 0
+                last_visible = getattr(self, '_ucat_last_visible', [])
+                if selected >= len(last_visible):
+                    return self._cmd_ucat_more()
+            return self._render_ucat()
         return self._make_dir_response()
     
     def _cmd_more(self, params):
@@ -929,9 +937,12 @@ class CompunetSession:
         except (ValueError, UnicodeDecodeError):
             return bytes([0x00])
 
-        # Find the page from current directory
-        offset = getattr(self, 'dir_page_offset', 0)
-        visible_children = self.current_page.children[offset:offset+11]
+        # Find the page from current directory (or UCAT if active)
+        if getattr(self, '_ucat_active', False):
+            visible_children = getattr(self, '_ucat_last_visible', [])
+        else:
+            offset = getattr(self, 'dir_page_offset', 0)
+            visible_children = self.current_page.children[offset:offset+11]
         if entry_idx >= len(visible_children):
             return bytes([0x00])
 
@@ -1777,12 +1788,16 @@ class CompunetSession:
         log.info('DIR: saved directory tree')
 
     def _cmd_ucat(self):
-        """UCAT command - list all pages owned by the current user."""
-        # Paging: advance offset on subsequent calls (MORE)
-        if not getattr(self, '_ucat_active', False):
-            self._ucat_offset = 0
-        else:
-            self._ucat_offset = getattr(self, '_ucat_offset', 0) + len(getattr(self, '_ucat_last_visible', []))
+        """UCAT command - list all pages owned by the current user.
+
+        Always resets to page 1. Paging (MORE) is handled by _cmd_ucat_more.
+        """
+        self._ucat_offset = 0
+        return self._render_ucat()
+
+    def _cmd_ucat_more(self):
+        """Advance UCAT to the next page of entries."""
+        self._ucat_offset = getattr(self, '_ucat_offset', 0) + len(getattr(self, '_ucat_last_visible', []))
         return self._render_ucat()
 
     def _render_ucat(self):

--- a/transfer-repo.sh
+++ b/transfer-repo.sh
@@ -7,7 +7,7 @@ REMOTE_URL="git@github.com:tgreaves/compunet-reborn.git"
 CONTAINER_NAME="repo-transfer-sim"
 
 # Only push branches that should exist on the remote
-BRANCHES="main 87-ucat-info-columns-not-consistent-with-normal-dir-view"
+BRANCHES="main 92-ucat---life-not-extending-still"
 
 echo "==> Bundling repository (active branches + tags)..."
 cd "$REPO_DIR"


### PR DESCRIPTION
LIFE command in UCAT now targets the correct entry from the UCAT visible list instead of the parent directory's children. Directory refresh after extend no longer advances the page. UCAT duckshoot command always resets to page 1.