### PR TITLE
Reverse video can be typed in the editor, and the toolbar tells the truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ client/c64/src/partyline/build/
 
 # Web client build artifacts (only app.bundle.js is tracked)
 client/web/dist/*.map
-client/web/dist/iff.test.mjs
+client/web/dist/*.test.mjs

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,11 +1,31 @@
 # 1.5.0 (unreleased)
 
+* Web & desktop client:
+	* New: Reverse video can now be typed in the editor - CTRL+9 turns it on,
+	  CTRL+0 off, and RETURN clears it, as on a real C64.  There is a toggle in
+	  the editor's tool panel too.  Until now the editor could display a reversed
+	  page but could not compose one (#136).
+	* Fixed: The editor's colour swatches did not follow the keyboard.  Setting
+	  the pen with CTRL+1-8, the screen or border with f7/f8, or moving between
+	  pages left the highlight showing whichever colour was last clicked.
+	* Fixed: The editor cursor blinked the wrong way round on a cell that was
+	  already reversed.  It could not be seen until reverse became typeable.
 * Server:
 	* Fixed: The audit log recorded an internal address instead of the user's for
 	  almost every entry.  Anything done from the web or Electron client was logged
 	  against the connection tunnel, and registrations, password changes and admin
 	  actions against the website itself.  Only sign-ins were correct.  Existing
 	  entries cannot be corrected - the real addresses were never recorded.
+* Specification:
+	* §8.4.3 now requires a client offering the editor to provide a way to author
+	  reverse video, recommends CTRL+9 / CTRL+0, and states the mode's lifetime:
+	  it ends at RETURN, and a line wrap does not end it.  It also warns that
+	  §A.5 records reverse as bit 7 of the screen code, which a client holding
+	  cells rather than screen codes must not copy - in the reference client that
+	  bit selects the character set instead.
+	* §8.4.3 now also requires that a palette, picker or mode indicator reflect
+	  current editor state rather than its own last click.
+	* §5.7 points at the authoring requirement; CONFORMANCE.md gains two checks.
 
 # 1.4.0 (2026-08-01)
 

--- a/client/electron/package-lock.json
+++ b/client/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compunet-reborn-desktop",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compunet-reborn-desktop",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "devDependencies": {
         "electron": "^33.0.0",
         "electron-builder": "^25.1.8"

--- a/client/web/dist/app.bundle.js
+++ b/client/web/dist/app.bundle.js
@@ -177,7 +177,11 @@ var Renderer = class {
     const g = cells.map((c) => ({ ...c }));
     if (cursor) {
       const i = row * COLS + col;
-      if (g[i]) g[i] = { ...g[i], fg: cursor.colour, rv: cursor.reverse ? 1 : 0 };
+      if (g[i]) g[i] = {
+        ...g[i],
+        fg: cursor.colour,
+        rv: g[i].rv ^ (cursor.reverse ? 1 : 0)
+      };
     }
     this.renderGrid(g, background);
     this.setBorder(border);
@@ -335,6 +339,15 @@ var EditorBuffer = class {
     this.colourOn = true;
     /** f5 "on/off auto-repeat": when off, held keys do not repeat. */
     this.autoRepeat = true;
+    /** ⚠ CTRL+9 / CTRL+0 — reverse video ($12/$92, §5.7), and like the pen colour
+     *  it is NOT in the help frame (§8.4.3) because it is not an editor command.
+     *  Verified in the ROM: the editor's key loop hands anything below $85 to
+     *  CHROUT ($888F -> JSR $FFD2), so $12/$92 reach the KERNAL's own reverse
+     *  handling unfiltered — the same route the colour keys take.
+     *
+     *  ⚠ A MODE, not a character. It stays on until $92 or a CARRIAGE RETURN, so
+     *  it spans cells and lives on the buffer rather than on any one of them. */
+    this.reverse = false;
     /** The page as last STORED, for RUN ("restore original"). */
     this.original = null;
     // --- cursor blink (§8.4.3) -----------------------------------------------
@@ -585,7 +598,12 @@ var EditorBuffer = class {
     this.touch();
     const i = this.row * PAGE_COLS + this.col;
     const fg = this.colourOn ? p.colour : p.cells[i].fg;
-    p.cells[i] = { g: charToGlyph(ch, this.lowerCase), fg, bg: p.background, rv: 0 };
+    p.cells[i] = {
+      g: charToGlyph(ch, this.lowerCase),
+      fg,
+      bg: p.background,
+      rv: this.reverse ? 1 : 0
+    };
     if (++this.col >= PAGE_COLS) {
       this.col = 0;
       this.moveRow(1);
@@ -628,8 +646,15 @@ var EditorBuffer = class {
     this.touch();
     p.cells[this.row * PAGE_COLS + this.col] = { g: 32, fg: p.colour, bg: p.background, rv: 0 };
   }
+  /** ⚠ A CARRIAGE RETURN CLEARS REVERSE (§5.7), as it does on the C64.
+   *
+   *  This is not cosmetic: the server's encoder emits a `$92` before every CR
+   *  (`_encode_cells`) and resets its own flag there, so a client that let the
+   *  mode survive a newline would disagree with its own wire format — the page
+   *  would come back un-reversed from that line on. */
   newline() {
     this.col = 0;
+    this.reverse = false;
     this.moveRow(1);
   }
   moveRow(d) {
@@ -668,7 +693,7 @@ var EditorBuffer = class {
     const i = this.row * PAGE_COLS + this.col;
     this.touch();
     const fg = this.colourOn ? p.colour : p.cells[i].fg;
-    p.cells[i] = { g: code & 255, fg, bg: p.background, rv: 0 };
+    p.cells[i] = { g: code & 255, fg, bg: p.background, rv: this.reverse ? 1 : 0 };
     if (++this.col >= PAGE_COLS) {
       this.col = 0;
       this.moveRow(1);
@@ -1106,10 +1131,13 @@ setInterval(() => {
   buf.tickCursor();
   renderEditor();
 }, CURSOR_BLINK_MS);
+var syncEditorTools = () => {
+};
 function renderEditor() {
   const p = buf.page();
   edRenderer.renderEditorPage(p.cells, p.background, p.border, buf.row, buf.col, buf.cursorState());
   $("edMeta").textContent = `page ${buf.cur + 1}/${buf.pages.length}` + (buf.editing ? ` \xB7 EDIT ${buf.row + 1},${buf.col + 1}` : "") + (p.raw ? " \xB7 captured" : "");
+  syncEditorTools();
 }
 var pendingUpload = null;
 var pendingDownloadKind = "P";
@@ -2216,6 +2244,13 @@ window.addEventListener("keydown", (e) => {
       e.preventDefault();
       return;
     }
+    if (e.ctrlKey && !e.altKey && (e.key === "9" || e.key === "0")) {
+      buf.reverse = e.key === "9";
+      render();
+      status(`Reverse ${buf.reverse ? "on" : "off"}`);
+      e.preventDefault();
+      return;
+    }
     if (e.shiftKey && !e.ctrlKey && !e.altKey && !buf.lowerCase && /^[A-Za-z]$/.test(e.key)) {
       buf.typeGlyph(64 + (e.key.toUpperCase().charCodeAt(0) - 64));
       render();
@@ -2368,10 +2403,19 @@ function buildEditorTools() {
   showBuffer();
   const swatches = $("edSwatches");
   const target = () => $("edTarget").value;
+  const revBtn = $("edReverse");
   const paint = () => {
     const p = buf.page();
     const cur = target() === "pen" ? p.colour : target() === "screen" ? p.background : p.border;
     [...swatches.children].forEach((el, i) => el.classList.toggle("on", i === cur));
+    revBtn.classList.toggle("on", buf.reverse);
+    revBtn.textContent = buf.reverse ? "on" : "off";
+  };
+  syncEditorTools = paint;
+  revBtn.onclick = () => {
+    buf.reverse = !buf.reverse;
+    render();
+    status(`Reverse ${buf.reverse ? "on" : "off"}`);
   };
   assets.palette.forEach((css, i) => {
     const b = document.createElement("button");

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -67,6 +67,9 @@
   .swatch { width: 18px; height: 18px; border: 1px solid #0008; border-radius: 3px; cursor: pointer;
             padding: 0; flex: none; }
   .swatch.on { outline: 2px solid var(--accent); outline-offset: 1px; }
+  .toggle { font: 11px ui-monospace, monospace; padding: 2px 10px; cursor: pointer; flex: none;
+            border: 1px solid var(--line); border-radius: 3px; background: #1b1b26; color: var(--dim); }
+  .toggle.on { background: var(--accent); border-color: var(--accent); color: #05050a; font-weight: 700; }
   /* The glyph strip scrolls rather than growing the pane — 64 cells a bank. */
   #edGlyphs { display: flex; gap: 2px; flex-wrap: wrap; max-height: 76px; overflow-y: auto;
               padding: 2px; background: #0a0a10; border: 1px solid var(--line); border-radius: 4px; }
@@ -184,6 +187,18 @@
             <option value="border">border · f8</option>
           </select>
           <div id="edSwatches"></div>
+        </div>
+        <!-- ⚠ An affordance for a MACHINE function, not a command (§8.4.3) — it
+             belongs in the pane furniture exactly as the palette does, never in
+             the editor's closed command row. It reads editor state rather than
+             its own last click, because RETURN clears the mode (§5.7) and a
+             toggle that missed that would say "on" while typing came out
+             un-reversed. -->
+        <div class="toolRow">
+          <span class="toolLabel">Reverse</span>
+          <button id="edReverse" class="toggle" type="button"
+                  title="Reverse video on / off. CTRL+9 turns it on, CTRL+0 off, and RETURN clears it as on the C64.">off</button>
+          <span class="toolNote">CTRL+9 / CTRL+0</span>
         </div>
         <div class="toolRow">
           <span class="toolLabel">Buffer</span>

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "compunet-web-client",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "compunet-web-client",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "devDependencies": {
         "esbuild": "^0.24.0",
         "typescript": "^5.6.0"

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -8,7 +8,9 @@
     "build": "esbuild src/main.ts --bundle --format=esm --sourcemap --outfile=dist/app.bundle.js",
     "watch": "esbuild src/main.ts --bundle --format=esm --sourcemap --watch --outfile=dist/app.bundle.js",
     "typecheck": "tsc --noEmit",
-    "test": "esbuild tests/iff.test.ts --bundle --platform=node --format=esm --outfile=dist/iff.test.mjs && node dist/iff.test.mjs"
+    "test": "npm run test:iff && npm run test:editor",
+    "test:iff": "esbuild tests/iff.test.ts --bundle --platform=node --format=esm --outfile=dist/iff.test.mjs && node dist/iff.test.mjs",
+    "test:editor": "esbuild tests/editor.test.ts --bundle --platform=node --format=esm --outfile=dist/editor.test.mjs && node dist/editor.test.mjs"
   },
   "devDependencies": {
     "esbuild": "^0.24.0",

--- a/client/web/src/editor.ts
+++ b/client/web/src/editor.ts
@@ -124,6 +124,15 @@ export class EditorBuffer {
   colourOn = true;
   /** f5 "on/off auto-repeat": when off, held keys do not repeat. */
   autoRepeat = true;
+  /** ⚠ CTRL+9 / CTRL+0 — reverse video ($12/$92, §5.7), and like the pen colour
+   *  it is NOT in the help frame (§8.4.3) because it is not an editor command.
+   *  Verified in the ROM: the editor's key loop hands anything below $85 to
+   *  CHROUT ($888F -> JSR $FFD2), so $12/$92 reach the KERNAL's own reverse
+   *  handling unfiltered — the same route the colour keys take.
+   *
+   *  ⚠ A MODE, not a character. It stays on until $92 or a CARRIAGE RETURN, so
+   *  it spans cells and lives on the buffer rather than on any one of them. */
+  reverse = false;
   /** The page as last STORED, for RUN ("restore original"). */
   private original: Cell[] | null = null;
 
@@ -373,7 +382,11 @@ export class EditorBuffer {
     const i = this.row * PAGE_COLS + this.col;
     // f6 off: the character changes, the colour under it does not.
     const fg = this.colourOn ? p.colour : p.cells[i].fg;
-    p.cells[i] = { g: charToGlyph(ch, this.lowerCase), fg, bg: p.background, rv: 0 };
+    p.cells[i] = { g: charToGlyph(ch, this.lowerCase), fg, bg: p.background,
+                   rv: this.reverse ? 1 : 0 };
+    // ⚠ The wrap does NOT clear reverse — only a CR does (§5.7). Running off
+    // the right-hand edge is not a newline, and a bar drawn to the screen edge
+    // is exactly the artwork that would break if it were.
     if (++this.col >= PAGE_COLS) { this.col = 0; this.moveRow(1); }
   }
 
@@ -406,7 +419,13 @@ export class EditorBuffer {
     p.cells[this.row * PAGE_COLS + this.col] = { g: 0x20, fg: p.colour, bg: p.background, rv: 0 };
   }
 
-  newline(): void { this.col = 0; this.moveRow(1); }
+  /** ⚠ A CARRIAGE RETURN CLEARS REVERSE (§5.7), as it does on the C64.
+   *
+   *  This is not cosmetic: the server's encoder emits a `$92` before every CR
+   *  (`_encode_cells`) and resets its own flag there, so a client that let the
+   *  mode survive a newline would disagree with its own wire format — the page
+   *  would come back un-reversed from that line on. */
+  newline(): void { this.col = 0; this.reverse = false; this.moveRow(1); }
 
   moveRow(d: number): void { this.row = Math.max(0, Math.min(PAGE_ROWS - 1, this.row + d)); }
   moveCol(d: number): void { this.col = Math.max(0, Math.min(PAGE_COLS - 1, this.col + d)); }
@@ -438,7 +457,7 @@ export class EditorBuffer {
     const i = this.row * PAGE_COLS + this.col;
     this.touch();
     const fg = this.colourOn ? p.colour : p.cells[i].fg;
-    p.cells[i] = { g: code & 0xFF, fg, bg: p.background, rv: 0 };
+    p.cells[i] = { g: code & 0xFF, fg, bg: p.background, rv: this.reverse ? 1 : 0 };
     if (++this.col >= PAGE_COLS) { this.col = 0; this.moveRow(1); }
   }
 

--- a/client/web/src/main.ts
+++ b/client/web/src/main.ts
@@ -420,6 +420,17 @@ setInterval(() => {
   renderEditor();
 }, CURSOR_BLINK_MS);
 
+/** ⚠ The editor's toolbar is DERIVED from editor state, not pushed into.
+ *
+ *  Assigned by buildEditorTools() and called from renderEditor(), so the
+ *  palette and the reverse toggle always show what the editor actually holds.
+ *  Pushing from each call site is what left the swatches stale: only a swatch
+ *  click repainted them, while CTRL+digit, f7/f8, LAST/NEXT (colour, screen and
+ *  border are all per-page) and GET all changed the same values silently. Five
+ *  routes against the one that remembered — and the sixth would have forgotten
+ *  too. It costs a handful of classList toggles a frame. */
+let syncEditorTools: () => void = () => { /* replaced once the tools exist */ };
+
 function renderEditor(): void {
   const p = buf.page();
   edRenderer.renderEditorPage(p.cells, p.background, p.border, buf.row, buf.col, buf.cursorState());
@@ -428,6 +439,7 @@ function renderEditor(): void {
   $('edMeta').textContent = `page ${buf.cur + 1}/${buf.pages.length}`
     + (buf.editing ? ` · EDIT ${buf.row + 1},${buf.col + 1}` : '')
     + (p.raw ? ' · captured' : '');
+  syncEditorTools();
 }
 
 /** Open the metadata form. The BODY comes from the editor buffer (§8.4.1) —
@@ -1706,6 +1718,20 @@ window.addEventListener('keydown', (e) => {
       status(`Pen colour ${bank[Number(e.key) - 1]}`);
       e.preventDefault(); return;
     }
+    // ⚠ CTRL+9 / CTRL+0 turn REVERSE VIDEO on and off ($12/$92, §5.7). Like the
+    // colour keys above this is a machine function rather than an editor
+    // command, which is why neither appears in the help frame (§A.9): verified
+    // in the ROM, the editor's key loop hands anything below $85 to CHROUT
+    // ($888F -> JSR $FFD2), so both codes reach the KERNAL untouched.
+    //
+    // A MODE, not a character — it holds until CTRL+0 or RETURN, so it is set
+    // on the buffer and read by every subsequent keystroke.
+    if (e.ctrlKey && !e.altKey && (e.key === '9' || e.key === '0')) {
+      buf.reverse = e.key === '9';
+      render();
+      status(`Reverse ${buf.reverse ? 'on' : 'off'}`);
+      e.preventDefault(); return;
+    }
     // ⚠ SHIFT + letter types a GRAPHICS character, as on the C64 — the keys are
     // the primary route and the picker is only an addition (§8.4.3). PETSCII
     // $C1-$DA (shifted letters) map to screen codes $41-$5A (§5.3), which is
@@ -1872,11 +1898,24 @@ function buildEditorTools(): void {
   const swatches = $('edSwatches');
   const target = () => $<HTMLSelectElement>('edTarget').value;
 
+  const revBtn = $<HTMLButtonElement>('edReverse');
+
   const paint = (): void => {
     // Show which colour is current for whatever the dropdown is pointing at.
     const p = buf.page();
     const cur = target() === 'pen' ? p.colour : target() === 'screen' ? p.background : p.border;
     [...swatches.children].forEach((el, i) => el.classList.toggle('on', i === cur));
+    // ⚠ Read from the buffer, never from the button's own history: the mode is
+    // also cleared by RETURN (§5.7), which no click handler would ever see.
+    revBtn.classList.toggle('on', buf.reverse);
+    revBtn.textContent = buf.reverse ? 'on' : 'off';
+  };
+  syncEditorTools = paint;
+
+  revBtn.onclick = () => {
+    buf.reverse = !buf.reverse;
+    render();
+    status(`Reverse ${buf.reverse ? 'on' : 'off'}`);
   };
 
   assets.palette.forEach((css, i) => {

--- a/client/web/src/render.ts
+++ b/client/web/src/render.ts
@@ -263,7 +263,14 @@ export class Renderer {
       // ⚠ Both halves matter. Reverse alone leaves the cursor invisible
       // wherever the cell's colour matches the background; the colour alone
       // would not read as a cursor at all.
-      if (g[i]) g[i] = { ...g[i], fg: cursor.colour, rv: cursor.reverse ? 1 : 0 };
+      //
+      // ⚠ XOR, not assignment. The original is `EOR #$80` ($87CC) — it toggles
+      // the cell's OWN reverse bit. Assigning was indistinguishable for as long
+      // as nothing could author a reversed cell; over one it pins the cursor to
+      // a fixed phase, so the blink reads inverted exactly where the user is
+      // working.
+      if (g[i]) g[i] = { ...g[i], fg: cursor.colour,
+                         rv: (g[i].rv ^ (cursor.reverse ? 1 : 0)) as 0 | 1 };
     }
     this.renderGrid(g, background);
     this.setBorder(border);

--- a/client/web/tests/editor.test.ts
+++ b/client/web/tests/editor.test.ts
@@ -1,0 +1,112 @@
+/* Editor tests for src/editor.ts — reverse video (§5.7 / §8.4.3) and the
+ * per-cell state it writes.
+ *
+ * Run:  npm test   (esbuild bundles this + editor.ts, node runs it — no framework)
+ *
+ * Reverse is the one typing attribute with a LIFETIME: it spans cells, and a
+ * carriage return ends it. Those are the cases here, because they are the ones
+ * a cell-at-a-time reading of the code gets wrong.
+ */
+import assert from 'node:assert';
+import { EditorBuffer, PAGE_COLS } from '../src/editor';
+
+let passed = 0;
+function test(name: string, fn: () => void): void {
+  fn();
+  passed++;
+  console.log('  ok  ' + name);
+}
+
+const cellAt = (b: EditorBuffer, row: number, col: number) =>
+  b.page().cells[row * PAGE_COLS + col];
+
+test('typing is not reversed by default', () => {
+  const b = new EditorBuffer();
+  b.typeChar('A');
+  assert.equal(cellAt(b, 0, 0).rv, 0);
+});
+
+test('reverse on: typed cells carry rv=1', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.typeChar('B');
+  assert.equal(cellAt(b, 0, 0).rv, 1);
+  assert.equal(cellAt(b, 0, 1).rv, 1, 'the mode spans cells');
+});
+
+test('reverse off again: later cells are plain', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.reverse = false;
+  b.typeChar('B');
+  assert.equal(cellAt(b, 0, 0).rv, 1);
+  assert.equal(cellAt(b, 0, 1).rv, 0);
+});
+
+test('graphics glyphs honour the mode too', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeGlyph(0x51);              // a filled circle, first graphics bank
+  assert.equal(cellAt(b, 0, 0).g, 0x51);
+  assert.equal(cellAt(b, 0, 0).rv, 1);
+});
+
+test('RETURN clears the mode (§5.7)', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.newline();
+  assert.equal(b.reverse, false, 'CR ends the run, as on the C64');
+  b.typeChar('B');
+  assert.equal(cellAt(b, 1, 0).rv, 0);
+});
+
+test('the column-40 wrap does NOT clear the mode', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  for (let i = 0; i < PAGE_COLS; i++) b.typeChar('X');   // fills row 0, wraps
+  assert.equal(b.row, 1, 'wrapped to the next row');
+  assert.equal(b.col, 0);
+  assert.equal(b.reverse, true, 'a wrap is not a carriage return');
+  b.typeChar('Y');
+  assert.equal(cellAt(b, 1, 0).rv, 1, 'a bar can run past the right edge');
+});
+
+test('backspace clears the cell rather than reversing it', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.backspace();
+  assert.equal(cellAt(b, 0, 0).rv, 0);
+  assert.equal(cellAt(b, 0, 0).g, 0x20);
+});
+
+test('reverse survives the RLE round-trip (PUT/STORE then GET)', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.reverse = false;
+  b.typeChar('B');
+  const saved = b.toJSON();
+
+  const back = new EditorBuffer();
+  back.load(saved);
+  assert.equal(back.page().cells[0].rv, 1, 'reversed cell came back reversed');
+  assert.equal(back.page().cells[1].rv, 0);
+});
+
+test('runs of differing rv are not merged by the RLE encoder', () => {
+  const b = new EditorBuffer();
+  b.reverse = true;
+  b.typeChar('A');
+  b.reverse = false;
+  b.typeChar('A');                // same glyph and colour, different rv
+  const runs = (JSON.parse(b.toJSON()) as { pages: { rle: number[][] }[] }).pages[0].rle;
+  assert.equal(runs[0][0], 1, 'first run is one cell, not two');
+  assert.equal(runs[0][4], 1, 'and it is the reversed one');
+  assert.equal(runs[1][4], 0);
+});
+
+console.log(`\n${passed} passed`);

--- a/docs/spec/05-display.md
+++ b/docs/spec/05-display.md
@@ -264,3 +264,7 @@ and the C64's screen-editor behaviour.)
 `$12` turns reverse video on and `$92` turns it off. While on, each rendered cell uses the
 **inverted** glyph (§5.4). `$0D`/carriage return clears the reverse attribute (as on the
 C64). A client **MUST** track this attribute per the control codes and apply it per cell.
+
+⚠ A client that offers the **editor** must also be able to **author** this, not merely render it
+— see §8.4.3, which carries the keys, the mode's lifetime, and the encoding trap that comes of
+§A.5 documenting reverse as bit 7 of the screen code.

--- a/docs/spec/08-subsystems.md
+++ b/docs/spec/08-subsystems.md
@@ -727,6 +727,7 @@ keys, and a client implementing the editor **SHOULD** provide all seven function
 | **f6** | colour on / off — when off, typing changes the character but not the colour under it |
 | **f7 / f8** | screen and border colour — **each press steps one colour forward** through the palette and wraps; they are not a forward/back pair (verified on the C64: yellow → orange → brown → light red → dark grey…) |
 | **`CTRL`+`1`–`8`** | set the **pen** colour — the colour typed text takes (`CTRL`+`4` is cyan). ⚠ See below |
+| **`CTRL`+`9` / `CTRL`+`0`** | **reverse video** on / off (`$12` / `$92`, §5.7). ⚠ See below |
 
 **⚠ The pen colour is set with `CTRL`+`1`–`8`, and it is NOT in the help frame (normative).**
 A client offering the editor **MUST** provide a way to set the colour typed text takes. On the
@@ -757,6 +758,13 @@ conditions:
   surrounding interface — a toolbar, a menu, a panel beside the page — the same place §4.10 puts
   the client's own furniture, and the same reasoning that keeps the buffer position out of the
   40×24 page (§8.4.2).
+- **⚠ It MUST reflect current state, not its own last click.** An affordance that shows a mode
+  **MUST** derive what it displays from the editor, because the keys change the same state and
+  some of it changes with no input at all — reverse video is cleared by a carriage return (§5.7),
+  which no click handler will ever see. A control that tracks only its own history will sit there
+  reading *on* while typing comes out plain, which is worse than not showing the mode: the user
+  now has a reason to believe the wrong thing. The same applies to a palette, whose highlight must
+  follow `CTRL`+digit, f7/f8 and a page change, not only a click on itself.
 
 **⚠ The same applies to GRAPHICS CHARACTERS, and here the gap is worse.** On the C64 the
 graphics come off the keyboard: `SHIFT`+letter gives one bank and `C=`+letter the other, which
@@ -776,6 +784,32 @@ nobody knows what `$6D` looks like.
 The same two conditions apply as for colour: **additional, not instead of** — whatever the
 keyboard *can* reach it still **MUST** reach — and **an affordance, not a command**, so no
 `GRAPH` or `CHARS` cell appears in the editor's row.
+
+**⚠ REVERSE VIDEO must be authorable, and it is the third of these (normative).** The pattern is
+by now familiar: a machine function the help frame does not list, whose absence leaves an editor
+that looks complete and silently cannot produce something §6 pages routinely contain. On the C64
+it is `CTRL`+`9` on and `CTRL`+`0` off, reaching the KERNAL by the same route as the colour keys —
+verified in the ROM, where the editor's key loop passes anything below `$85` to `CHROUT`
+(`$888F`: `JSR $FFD2`), so `$12`/`$92` are never intercepted by the editor at all. A client
+offering the editor **MUST** provide a way to author reverse video; `CTRL`+`9`/`CTRL`+`0` is
+**RECOMMENDED** because it matches the original exactly.
+
+**⚠ It is a MODE with a LIFETIME, not a property of one cell.** It stays on until `$92` **or a
+carriage return** (§5.7), and a **line wrap does not end it** — running off the right-hand edge is
+not a newline, and a reversed bar drawn to the screen edge is exactly the artwork that would break
+if it were. A client **MUST** clear the mode on `RETURN`: the frame encoder emits `$92` before
+every CR, so an editor whose mode outlived a newline would disagree with its own wire format and
+upload a page un-reversed from that line on, while still showing the mode as active.
+
+**⚠ Do not conflate reverse with the character set.** §A.5 documents screen codes `$80`–`$FF` as
+the reverse-video forms of `$00`–`$7F`, because on hardware reverse **is** bit 7 of the byte in
+screen RAM — the original sets it by hand where `CHROUT` is not involved (`$AA43`:
+`ORA #$80 / STA $07C0,X`). A client holding §6 **cells** rather than screen codes carries reverse
+as a per-cell attribute instead, and its glyph index is then free to mean something else: in the
+reference client bit 7 of the glyph selects the **character set**. Setting bit 7 to obtain reverse
+in such a model silently switches charset — `A` becomes a different glyph entirely — and the
+result looks plausible enough to survive review. Whichever encoding a client picks, capture
+(§8.4.2) must preserve the attribute either way.
 
 This is the general principle of §4.6 applied to the editor: *how* something is invoked is the
 client's business, *what exists to be invoked* is not.

--- a/docs/spec/CONFORMANCE.md
+++ b/docs/spec/CONFORMANCE.md
@@ -91,6 +91,16 @@ marked **⚠** are the ones known to have been got wrong in practice.
       cyan. Type a character, change the pen, type another: they must differ. A client that
       implements only the help frame's keys can produce **white text and nothing else**, which
       looks like a working editor until you try to author a coloured page.
+- [ ] **⚠ Reverse video can be typed at all** (§8.4.3). `CTRL`+`9`, type, `CTRL`+`0`, type: the
+      two runs must differ. Then check the **lifetime**, which is where this goes wrong — press
+      `RETURN` and the mode must clear (§5.7), and type past column 40 with it on, where the wrap
+      must **not** clear it. A client that renders reverse perfectly on pages it receives can
+      still be unable to author a single reversed cell, and nothing on screen says so.
+- [ ] **⚠ Any palette, picker or mode indicator follows the keys** (§8.4.3). Set the pen with
+      `CTRL`+digit and watch the swatches; press f7/f8 with the target on screen or border; page
+      with `LAST`/`NEXT`, which changes all three at once. An affordance that repaints only on its
+      own click reports the previous state confidently, and the reverse toggle is worse than the
+      palette here because `RETURN` changes the mode with no input the control can observe.
 - [ ] **⚠ Changing the screen colour actually changes the screen** (§8.4.3). Press f7 and watch
       the whole 40×24 area, not the status line: if the model holds a background per cell, the
       page field and the cells will disagree and only newly typed cells change. f8 (border) is

--- a/server/tests/test_api_binding.py
+++ b/server/tests/test_api_binding.py
@@ -454,6 +454,41 @@ class FrameFidelity(unittest.TestCase):
             self.assertEqual(got['rv'], sent['rv'], 'reverse at %d' % i)
             self.assertEqual(got['fg'], sent['fg'], 'colour at %d' % i)
 
+    def test_a_reversed_run_is_bracketed_by_12_and_92(self):
+        """§5.7: reverse is a MODE on the wire, not a property carried by each
+        cell — `$12` opens a run and `$92` closes it. The round-trip test above
+        would still pass if the encoder invented some other mechanism; this pins
+        the bytes, because a real C64 has no other way to read them."""
+        cells = [{'g': 0x20, 'fg': 1, 'bg': 0, 'rv': 0} for _ in range(960)]
+        for c in range(3):
+            cells[c] = {'g': 0x01, 'fg': 1, 'bg': 0, 'rv': 1}
+        out = api._encode_frame(self._grid(cells))
+        self.assertIn(b'\x12', out, 'no reverse-on code emitted at all')
+        self.assertEqual(out.count(b'\x12'), 1, 'one run should mean one switch')
+        self.assertLess(out.index(b'\x12'), out.index(b'\x92'),
+                        'reverse switched off before it was switched on')
+        self.assertLess(out.index(b'\x92'), out.index(b'\x0d'),
+                        'the run must close before the line ends')
+
+    def test_reverse_never_survives_a_carriage_return(self):
+        """§5.7 — a CR clears the attribute, and the encoder resets its own flag
+        there. The web editor's newline() clears its typing mode for exactly
+        this reason: without it the page would upload un-reversed from that line
+        on while the editor went on showing the mode as still active."""
+        cells = [{'g': 0x20, 'fg': 1, 'bg': 0, 'rv': 0} for _ in range(960)]
+        for i in range(2 * 40):
+            cells[i] = {'g': 0x01, 'fg': 1, 'bg': 0, 'rv': 1}
+        out = api._encode_frame(self._grid(cells))
+        reverse = False
+        for i, b in enumerate(out[4:], start=4):
+            if b == 0x12:
+                reverse = True
+            elif b == 0x92:
+                reverse = False
+            elif b == 0x0d:
+                self.assertFalse(reverse,
+                                 'reverse left switched on across the CR at byte %d' % i)
+
     def test_raw_round_trips_byte_identically(self):
         """F26/§8.4.2: an unedited captured page republishes unchanged."""
         import base64


### PR DESCRIPTION
Closes #136 — reported by ZARD, who asked how to type reverse characters in the web editor. The answer was that you couldn't.

## The gap

The editor could *display* reverse video, capture a reversed page, and re-upload it byte-for-byte — but it could not compose a single reversed cell. `typeChar` and `typeGlyph` both wrote `rv: 0` unconditionally, and nothing bound a key or offered a control. Not even the obvious workaround helped: capturing a reversed page and typing over it still wrote plain cells.

## Verified before building

The cartridge editor reads keys with `JSR $FFE4` and passes anything below `$85` to CHROUT (`$888F -> JSR $FFD2`), so `$12`/`$92` reach the KERNAL's own reverse handling unfiltered — the same route the pen colour keys take, which is why neither appears in the editor's help frame (§A.9).

So it is a **mode, not a character**: on until `$92` or a carriage return (§5.7), and a line wrap does not end it.

## What changed

**Client** (`client/web/`)

- `editor.ts` — `reverse` flag on `EditorBuffer`; `typeChar`/`typeGlyph` write it into `rv`; `newline()` clears it; the column-40 wrap deliberately does not
- `main.ts` — `CTRL+9` on, `CTRL+0` off, with status feedback
- `index.html` — a reverse toggle in the editor tool panel, an affordance under §8.4.3
- `render.ts` — the cursor now XORs the cell's own `rv` (`EOR #$80`, `$87CC`) instead of assigning it

⚠ **Reverse goes in `rv`, never bit 7 of `g`.** §A.5 records `$80`–`$FF` as the reverse forms because on hardware reverse *is* bit 7 of screen RAM, but this client's font is set 1 followed by set 2, so bit 7 of `g` selects the **character set**. OR-ing `$80` in to get reverse would silently switch charset and look plausible enough to survive review. The spec now says so.

**A toolbar bug the toggle exposed**

`paint()` ran only from a swatch click, so `CTRL`+digit, f7/f8, `LAST`/`NEXT` and `GET` all changed colour while the highlight went on showing whatever was last clicked. The toolbar is now derived on the render path — which the reverse toggle needs anyway, because `RETURN` clears the mode with no input a click handler could ever observe.

**Specification**

- §8.4.3 — reverse video as the third ⚠ authoring requirement beside pen colour and graphics characters; `CTRL+9`/`CTRL+0` RECOMMENDED; the mode's lifetime; the bit-7 trap
- §8.4.3 — a third condition on affordances: they MUST reflect current editor state, not their own last click
- §5.7 — points at the authoring requirement
- CONFORMANCE.md — two new checks

## Not touched

- **No C64 client change.** The ROM already does this natively through CHROUT, and it is feature-locked.
- **No server change.** `rv` is handled end to end already; two new tests pin the `$12`/`$92` bytes and that reverse never survives a CR.

## Testing

- 13 web tests (9 new: mode spans cells, RETURN clears, wrap does not, glyphs honour it, RLE round-trip, runs not merged across differing `rv`), `tsc --noEmit` clean
- 92 server tests, 2 new
- Exercised in the running client: reversed cells measure 53–63% ink against 28% for the plain run between them. `CTRL+9`/`CTRL+0` drive the status line and the toggle, `CTRL+8` moves the swatch highlight, and `RETURN` flips the toggle off by itself
- `CTRL+9` confirmed working in a real Chrome by @tgreaves — it is not intercepted as "last tab"
- Full `npm run dist:win` rebuild per the client rules

## One thing still unverified

That `CTRL+9` emits `$12` on a *C64* keyboard rests on nothing in this repo — there is no KERNAL disassembly here. The mode semantics do not depend on it; only the choice of binding does, and §8.4.3 marks it RECOMMENDED rather than required. One VICE breakpoint on `$FFE4` would settle it.

## Unrelated, found on the way

The server suite is largely inert on a clean checkout — filed as #137 (gitignored fixture account: 61 skips and one misleading failure) and #138 (`test_terminal`/`test_tree`, different cause, not diagnosed). Neither is touched here. The one pre-existing failure in `test_api_binding` is #137's and predates this branch.
