### PR TITLE
Make the server suite actually run on a clean checkout

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -26,7 +26,9 @@
 	  Windows separators, which do not resolve on macOS or Linux.  Every test that
 	  walked into a sub-directory failed there - the whole of test_terminal and 41
 	  of test_tree's 55 (#138).  The tree writer already normalised these; the
-	  fixture predated it.
+	  fixture predated it.  test_tree now guards every shipped tree against both
+	  a Windows separator and a sub-directory entry pointing nowhere, walking to
+	  any depth - the first pass at this missed four entries three levels down.
 	* Fixed: test_audit could not deliver mail on Python 3.14, because sending
 	  schedules the recipient's notification on the event loop and the harness
 	  provided none.  It reported itself as the audit gap it was written to guard.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -16,6 +16,20 @@
 	  against the connection tunnel, and registrations, password changes and admin
 	  actions against the website itself.  Only sign-ins were correct.  Existing
 	  entries cannot be corrected - the real addresses were never recorded.
+* Tests:
+	* Fixed: The server test suite did almost nothing on a clean checkout and said
+	  OK while doing it.  61 of test_api_binding's 92 tests and 10 of test_audit's
+	  skipped because the account they log in as lives in a gitignored file, and a
+	  skip reads as a pass (#137).  A fixture account is now supplied when one is
+	  missing; a machine that already has a working TEST account is untouched.
+	* Fixed: The tracked content fixture recorded its sub-directory paths with
+	  Windows separators, which do not resolve on macOS or Linux.  Every test that
+	  walked into a sub-directory failed there - the whole of test_terminal and 41
+	  of test_tree's 55 (#138).  The tree writer already normalised these; the
+	  fixture predated it.
+	* Fixed: test_audit could not deliver mail on Python 3.14, because sending
+	  schedules the recipient's notification on the event loop and the harness
+	  provided none.  It reported itself as the audit gap it was written to guard.
 * Specification:
 	* §8.4.3 now requires a client offering the editor to provide a way to author
 	  reverse video, recommends CTRL+9 / CTRL+0, and states the mode's lifetime:

--- a/server/data/content.test/root/jungle/directory.json
+++ b/server/data/content.test/root/jungle/directory.json
@@ -26,7 +26,7 @@
       "frames": [
         "frame-1.seq"
       ],
-      "directory": "jungle\\the-zoo\\directory.json"
+      "directory": "jungle/the-zoo/directory.json"
     },
     {
       "page_num": 601,
@@ -38,7 +38,7 @@
       "frames": [
         "frame-1.seq"
       ],
-      "directory": "jungle\\graphics\\directory.json"
+      "directory": "jungle/graphics/directory.json"
     },
     {
       "page_num": 602,
@@ -83,7 +83,7 @@
       "frames": [
         "frame-1.seq"
       ],
-      "directory": "jungle\\ash-and-dave\\directory.json"
+      "directory": "jungle/ash-and-dave/directory.json"
     },
     {
       "page_num": 902,
@@ -128,7 +128,7 @@
       "author": "JUNGLE",
       "price": 0.0,
       "life": 0,
-      "directory": "jungle\\more\\directory.json"
+      "directory": "jungle/more/directory.json"
     }
   ]
 }

--- a/server/data/content.test/root/jungle/the-zoo/directory.json
+++ b/server/data/content.test/root/jungle/the-zoo/directory.json
@@ -27,7 +27,7 @@
       "author": "PIMAN",
       "price": 0,
       "life": 99,
-      "directory": "jungle\\the-zoo\\march\\directory.json"
+      "directory": "jungle/the-zoo/march/directory.json"
     },
     {
       "page_num": 706,
@@ -36,7 +36,7 @@
       "author": "PIMAN",
       "price": 0,
       "life": 99,
-      "directory": "jungle\\the-zoo\\april\\directory.json"
+      "directory": "jungle/the-zoo/april/directory.json"
     },
     {
       "page_num": 710,
@@ -45,7 +45,7 @@
       "author": "PIMAN",
       "price": 0,
       "life": 99,
-      "directory": "jungle\\the-zoo\\may\\directory.json"
+      "directory": "jungle/the-zoo/may/directory.json"
     },
     {
       "page_num": 714,
@@ -54,7 +54,7 @@
       "author": "PIMAN",
       "price": 0,
       "life": 99,
-      "directory": "jungle\\the-zoo\\july\\directory.json"
+      "directory": "jungle/the-zoo/july/directory.json"
     },
     {
       "page_num": 718,

--- a/server/data/content.test/root/root.json
+++ b/server/data/content.test/root/root.json
@@ -24,7 +24,7 @@
       "frames": [
         "frame-1.seq"
       ],
-      "directory": "jungle\\directory.json"
+      "directory": "jungle/directory.json"
     },
     {
       "page_num": 900,
@@ -34,7 +34,7 @@
       "price": 0,
       "life": 0,
       "keyword": "PARTYLINE",
-      "directory": "partyline\\directory.json"
+      "directory": "partyline/directory.json"
     },
     {
       "page_num": 800,

--- a/server/tests/README.md
+++ b/server/tests/README.md
@@ -14,6 +14,29 @@ No dependencies — stdlib `unittest`, no sockets, no Electron. `test_api_bindin
 drives `api_binding.handle_message()` directly against the tracked fixture tree
 (`server/data/content.test`), so a full run takes about four seconds.
 
+## The login account
+
+The suites log in as `TEST`/`SECRET`. That account lives in
+`server/cfg/users.json`, which holds live accounts and password hashes and is
+therefore gitignored — so on a clean checkout it does not exist.
+
+`tests/fixture_account.py` supplies one when it is missing, in a temporary
+directory that `srv.CFG_DIR` is pointed at. **A machine that already has a
+working `TEST` account keeps using it**: the real `users.json` is read once to
+answer that question and is never written to, moved or replaced.
+
+⚠ Until this existed the account's absence was invisible. `session()` skips when
+`TEST` cannot log in, and a skip reads as a pass — so **61 of `test_api_binding`'s
+92 tests and 10 of `test_audit`'s did nothing at all** on any machine without a
+hand-built account, while the suite reported `OK`. The one test that logs in
+without going through `session()` failed instead, and its docstring describes a
+real shipped bug, so the natural reading was an audit regression rather than a
+missing fixture (#137).
+
+If you add a test needing more than a plain account with credit, put it in
+`fixture_account.ACCOUNTS` rather than in the test, so every suite keeps
+agreeing about who `TEST` is.
+
 `test_terminal` covers port 6401. ⚠ **It exists because that surface had no tests
 at all**, which is how it kept its own hand-copied reimplementation of the upload
 writer long enough to drift from the shared one in four separate ways — including

--- a/server/tests/fixture_account.py
+++ b/server/tests/fixture_account.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The account the suites log in as, supplied only when the real one is absent.
+
+`server/cfg/users.json` holds live accounts and their password hashes, so it is
+gitignored and cannot be committed. The suites log in as TEST/SECRET, and on a
+clean checkout that account simply does not exist — which made 61 of
+`test_api_binding`'s tests skip SILENTLY and one fail outright (#137). A skip
+reads as a pass, so the suite that exists because "every clean-room run of
+Binding B has found bugs introduced by the previous round of fixes" was not in
+fact guarding those paths for anybody who had not hand-built an account.
+
+⚠ A MACHINE THAT ALREADY HAS A WORKING TEST ACCOUNT KEEPS USING IT. `ensure()`
+supplies one only when the real configuration cannot authenticate, so a
+developer with a set-up environment sees no change at all: their `users.json` is
+read to answer that one question and is never written to, moved, or replaced.
+The fallback redirects `srv.CFG_DIR` at a temp directory instead, which also
+means a test that writes users back (`_save_users`) cannot reach the real file.
+
+The account is deliberately minimal — enough credit for the paid-page paths and
+nothing else. If a test ever needs more than that, add it here rather than in
+the test, so both suites keep agreeing about who TEST is.
+"""
+
+import atexit
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+
+USER, PASSWORD = 'TEST', 'SECRET'
+
+#: Enough to buy the fixture tree's paid pages several times over. The tests
+#: that care assert on the DELTA, not the balance, so the figure is arbitrary.
+CREDIT = 100.0
+
+#: ⚠ ADMIN is here because it is a RECIPIENT, not because anything logs in as
+#: it: the audit suite sends mail to ADMIN, and without the account the send is
+#: refused with "no such user" — which surfaces as "Binding B mail must be
+#: audited" and reads exactly like the audit bug that test was written to guard.
+#: `data/mail.test` ships mailboxes for TEST and ADMIN and nobody else, so that
+#: pair is what the fixture set has always assumed.
+#:
+#: Neither account carries `admin` or `editor`. Those flags short-circuit the
+#: upload permission check (§ _may_upload_here), so granting them would quietly
+#: stop the open_upload paths from being tested at all.
+ACCOUNTS = {
+    USER: {'credit': CREDIT, 'purchased': []},
+    'ADMIN': {'credit': 0.0, 'purchased': []},
+}
+
+
+def _hashed(password):
+    """Exactly what CompunetSession._hash_password does — SHA-256 of the
+    upper-cased password, since handle_login upper-cases before comparing."""
+    return hashlib.sha256(password.upper().strip().encode('utf-8')).hexdigest()
+
+
+def _already_works(cfg_dir):
+    """Can the REAL configuration log TEST in? Read-only, and never raises: a
+    missing, unreadable or malformed users.json simply means "no"."""
+    path = os.path.join(cfg_dir, 'users.json')
+    try:
+        with open(path, 'r') as f:
+            users = json.load(f)
+    except (OSError, ValueError):
+        return False
+    user = users.get(USER)
+    return bool(user) and user.get('password') == _hashed(PASSWORD)
+
+
+def ensure(srv):
+    """Guarantee USER/PASSWORD can log in.
+
+    Returns 'existing' when the machine's own configuration already works and
+    nothing was changed, or 'synthetic' when a temporary account was created and
+    `srv.CFG_DIR` repointed at it for the life of the process.
+    """
+    if _already_works(srv.CFG_DIR):
+        return 'existing'
+
+    tmp = tempfile.mkdtemp(prefix='compunet-cfg-')
+    users = {name: dict(rec, password=_hashed(PASSWORD))
+             for name, rec in ACCOUNTS.items()}
+    with open(os.path.join(tmp, 'users.json'), 'w') as f:
+        json.dump(users, f)
+    srv.CFG_DIR = tmp
+    atexit.register(shutil.rmtree, tmp, True)
+    return 'synthetic'

--- a/server/tests/test_api_binding.py
+++ b/server/tests/test_api_binding.py
@@ -66,7 +66,13 @@ import api_binding as api              # noqa: E402
 
 api._bind_server(srv)
 
-USER, PASSWORD = 'TEST', 'SECRET'
+# ⚠ Supply the login account when this machine has none (#137). A machine with a
+# working TEST account keeps using it — see tests/fixture_account.py.
+sys.path.insert(0, _HERE)
+import fixture_account                  # noqa: E402
+fixture_account.ensure(srv)
+
+USER, PASSWORD = fixture_account.USER, fixture_account.PASSWORD
 JUNGLE, GRAPHICS, THE_ZOO, MORE_DIR = 600, 601, 699, 909
 
 

--- a/server/tests/test_audit.py
+++ b/server/tests/test_audit.py
@@ -14,6 +14,7 @@ independently and asserted to produce the event. A future binding that reuses th
 core inherits the coverage for free; one that reimplements an action fails here.
 """
 
+import asyncio
 import json
 import os
 import shutil
@@ -34,7 +35,12 @@ import partyline as pl            # noqa: E402
 
 api._bind_server(srv)
 
-USER, PASSWORD = 'TEST', 'SECRET'
+# ⚠ As in test_api_binding: supply the account only if this machine lacks one.
+sys.path.insert(0, _HERE)
+import fixture_account                  # noqa: E402
+fixture_account.ensure(srv)
+
+USER, PASSWORD = fixture_account.USER, fixture_account.PASSWORD
 
 
 class AuditTestCase(unittest.TestCase):
@@ -46,10 +52,27 @@ class AuditTestCase(unittest.TestCase):
         self._saved_mail = srv.MAIL_DIR
         srv.AUDIT_LOG_PATH = os.path.join(self._tmp, 'audit.jsonl')
         srv.MAIL_DIR = os.path.join(self._tmp, 'mail')
+        # ⚠ A LOOP MUST EXIST, because delivering mail schedules the recipient's
+        # notification with `asyncio.get_event_loop().create_task(...)`
+        # (_complete_mail_send). In the server that call is always reached from
+        # inside a request handler, so a running loop is there; a test calling
+        # the sync function directly has none, and from Python 3.14 that is a
+        # RuntimeError rather than a warning — which surfaced as "Binding B mail
+        # must be audited" and read exactly like the bug the test guards.
+        # Providing the loop keeps the assertion honest without softening the
+        # server to suit the harness.
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
 
     def tearDown(self):
         srv.AUDIT_LOG_PATH = self._saved_path
         srv.MAIL_DIR = self._saved_mail
+        # Notification tasks were scheduled, never run; cancel them so closing
+        # the loop does not warn about pending work.
+        for task in asyncio.all_tasks(self._loop):
+            task.cancel()
+        asyncio.set_event_loop(None)
+        self._loop.close()
         shutil.rmtree(self._tmp, ignore_errors=True)
 
     def events(self, name=None):

--- a/server/tests/test_tree.py
+++ b/server/tests/test_tree.py
@@ -76,6 +76,77 @@ class TheShippedTreesHaveUniquePageNumbers(unittest.TestCase):
                          'entries not reachable by their own page number')
 
 
+class TheShippedTreesUsePortablePaths(unittest.TestCase):
+    """A sub-directory recorded with a Windows separator is INVISIBLE on the
+    host that serves this tree.
+
+    `content.test` recorded its children as `jungle\\directory.json`. That
+    resolves on Windows and nowhere else, so on macOS and on the Linux host the
+    sub-tree simply was not there — the whole of `test_terminal` and 41 of this
+    file's 55 tests failed, and `test_api_binding` reported entries missing by
+    page number (#138). The tree WRITER already normalises this and says why;
+    the tracked fixture predated it.
+
+    ⚠ Walk to ANY DEPTH. The first pass at this fixed `root.json` and
+    `jungle/directory.json` and declared victory, because the check only looked
+    two levels down — `jungle/the-zoo/directory.json` kept four more, and every
+    test still passed because nothing happened to descend that far. A guard that
+    stops where the bug was last seen is not a guard.
+    """
+
+    TREES = ('data/content.test', 'data.example')
+
+    def test_no_sub_directory_path_uses_a_windows_separator(self):
+        offenders = []
+        for rel in self.TREES:
+            for base, _dirs, files in os.walk(os.path.join(_SERVER, rel)):
+                for name in files:
+                    if not name.endswith('.json'):
+                        continue
+                    path = os.path.join(base, name)
+                    with open(path, encoding='utf-8') as f:
+                        try:
+                            data = json.load(f)
+                        except ValueError:
+                            continue
+                    if not isinstance(data, dict):
+                        continue
+                    for page in data.get('pages', []):
+                        target = isinstance(page, dict) and page.get('directory')
+                        if target and '\\' in target:
+                            offenders.append('%s -> %s'
+                                             % (os.path.relpath(path, _SERVER), target))
+        self.assertEqual([], offenders,
+                         'sub-directory paths that will not resolve off Windows')
+
+    def test_every_sub_directory_path_exists_on_disk(self):
+        """The other half: a path that resolves but points nowhere is the same
+        invisible sub-tree, and separator-only checking would not catch it."""
+        missing = []
+        for rel in self.TREES:
+            root = os.path.join(_SERVER, rel)
+            content_root = os.path.join(root, 'root')
+            if not os.path.isdir(content_root):
+                continue
+            for base, _dirs, files in os.walk(content_root):
+                for name in files:
+                    if name != 'directory.json' and name != 'root.json':
+                        continue
+                    path = os.path.join(base, name)
+                    with open(path, encoding='utf-8') as f:
+                        try:
+                            data = json.load(f)
+                        except ValueError:
+                            continue
+                    for page in data.get('pages', []):
+                        target = isinstance(page, dict) and page.get('directory')
+                        if target and not os.path.exists(
+                                os.path.join(content_root, target)):
+                            missing.append('%s -> %s'
+                                           % (os.path.relpath(path, _SERVER), target))
+        self.assertEqual([], missing, 'sub-directory entries pointing nowhere')
+
+
 class ADuplicatePageNumberIsRefused(unittest.TestCase):
     """⚠ Page numbers are the tree's identity: `GOTO` resolves through them and
     every edit addresses a page by one. A repeated number is therefore ambiguous,


### PR DESCRIPTION
Closes #137. Closes #138 — the second turned out to be a one-line-per-path fixture problem, not a separate investigation.

## The state of things

262 server tests. On a clean checkout **206 of them did nothing**, and the suite reported `OK` while doing it.

| Suite | Before | After |
|---|---|---|
| `test_api_binding` | 1 failed, 61 of 92 skipped | **OK** |
| `test_terminal` | 14 of 14 errored | **OK** |
| `test_audit` | OK, 10 skipped | **OK** |
| `test_tree` | 3 failed, 38 errored | **OK** |
| `test_header_frame` / `test_x25` / `test_client_conformance` | OK | OK |

Three independent causes, none of them the code under test.

## 1. The login account is not in the repo (#137)

The suites log in as `TEST`/`SECRET`, which lives in `server/cfg/users.json` — live accounts and password hashes, correctly gitignored. `session()` skips when it cannot log in, and **a skip reads as a pass**.

`server/tests/fixture_account.py` now supplies the account when it is missing, in a temp directory that `srv.CFG_DIR` is pointed at.

### ⚠ A configured machine is untouched

This was the explicit requirement, so it is tested rather than asserted. The real `users.json` is read once to answer "can `TEST` log in?" and is never written to, moved or replaced.

| Environment | Mode | Suites |
|---|---|---|
| No `users.json` (clean checkout) | `synthetic` | OK |
| **Real `users.json`, `TEST` works** | **`existing`** | **OK**, file byte-identical afterwards |
| `users.json` present, no `TEST` | `synthetic` | OK |
| `users.json` malformed | `synthetic` | OK |

A side benefit of the fallback: `_save_users()` writes into the temp directory, so a test that persists users cannot reach a developer's real file.

`ADMIN` is in the fixture because it is a **recipient**, not because anything logs in as it. The audit suite sends mail to `ADMIN`; without the account the send is refused with "no such user", which surfaces as *"Binding B mail must be audited"* and reads exactly like the audit bug that test was written to guard. `data/mail.test` ships mailboxes for `TEST` and `ADMIN` and nobody else, so that pair is what the fixtures always assumed. Neither account carries `admin` or `editor` — those short-circuit `_may_upload_here()` and would quietly stop the `open_upload` paths being tested at all.

## 2. The content fixture used Windows separators (#138)

`content.test` recorded sub-directory paths as `jungle\directory.json`. That resolves on Windows and does not on macOS, or on the Linux host that actually serves this tree, so every test that walked into a sub-directory failed — the whole of `test_terminal` and 41 of `test_tree`'s 55.

The tree **writer** already normalises this and says why:

> Forward slashes: `os.path.relpath` yields backslashes on Windows, and those do not resolve on the Linux host that actually serves this tree.

The tracked fixture predated that fix. Six paths in two files.

## 3. Mail could not be delivered under test on Python 3.14

`_complete_mail_send` schedules the recipient's notification with `asyncio.get_event_loop().create_task(...)`. In the server that is always reached from inside a request handler, so a running loop is there; a test calling the sync function directly has none, and from Python 3.14 that raises instead of warning.

**Fixed in the harness, not the server** — `AuditTestCase` now provides a loop, so the assertion stays honest rather than the server being softened to suit it. Production is unaffected either way: the Dockerfile pins `python:3.12`.

## Worth a look separately

The content **reader** does not normalise separators, only the writer does. A tree written by an older Windows build would still have its sub-directories invisible on the Linux host — silently, exactly as the fixture was. Worth checking whether any `directory` value in the live tree still contains a backslash; I have not touched the reader here.
