### PR TITLE
Accept a tree written on Windows, and say which sub-directory is missing

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -29,6 +29,17 @@
 	  fixture predated it.  test_tree now guards every shipped tree against both
 	  a Windows separator and a sub-directory entry pointing nowhere, walking to
 	  any depth - the first pass at this missed four entries three levels down.
+	* Fixed: A sub-directory whose path was recorded with Windows separators was
+	  invisible to the server on macOS and Linux, and a sub-directory that could
+	  not be found was skipped without a word - so a whole branch of the service
+	  disappeared and the only symptom was a listing that was shorter than it
+	  should be (#141).  The reader now accepts either separator and says which
+	  page it could not follow.  New: server/check_content_tree.py reports both
+	  faults for any tree, without needing the server running.
+	* Fixed: The example content tree shipped three sub-directory entries -
+	  GRAPHICS, MUSIC and DEMOS - pointing at files that were never in it.  An
+	  operator starting from data.example got three empty branches and no
+	  indication why.
 	* Fixed: test_audit could not deliver mail on Python 3.14, because sending
 	  schedules the recipient's notification on the event loop and the harness
 	  provided none.  It reported itself as the audit gap it was written to guard.

--- a/server/check_content_tree.py
+++ b/server/check_content_tree.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Report content-tree entries the server will silently fail to load.
+
+    python3 server/check_content_tree.py [CONTENT_DIR]
+
+With no argument it uses $COMPUNET_CONTENT_DIR, falling back to
+server/data/content — the same resolution the server does, so running it on the
+host with the service's own environment checks the tree actually being served.
+
+READ-ONLY. It opens JSON files and stats paths; it writes nothing and needs no
+dependencies beyond the standard library, so it can be dropped onto a server and
+run without installing anything.
+
+Two faults, both of which make a whole branch of the service vanish while every
+file for it sits on disk:
+
+  SEPARATOR   `"directory": "jungle\\directory.json"` resolves on Windows and
+              nowhere else. The writer has normalised to forward slashes since
+              it learned this; trees written before that fix still carry them.
+
+  MISSING     A `directory` value that resolves but points at no file. Same
+              symptom, different cause, and a separator-only check misses it.
+
+Exit status is 1 if anything is found, so it can be wired into a deploy check.
+"""
+
+import json
+import os
+import sys
+
+
+def _entries(path):
+    """Yield (page_num, title, directory_value) for one JSON file."""
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, ValueError) as exc:
+        print('  ?? unreadable: %s (%s)' % (path, exc))
+        return
+    if not isinstance(data, dict):
+        return
+    for page in data.get('pages', []):
+        if isinstance(page, dict) and page.get('directory'):
+            yield page.get('page_num'), page.get('title'), page['directory']
+
+
+def check(content_dir):
+    root = os.path.join(content_dir, 'root')
+    if not os.path.isdir(root):
+        print('No tree at %s (expected a "root" directory inside it)' % content_dir)
+        return 2
+
+    separator, missing, files = [], [], 0
+    # ⚠ Walk to ANY DEPTH. A check that stops where the fault was last seen is
+    # not a check: the first sweep of the test fixture looked two levels down,
+    # fixed six entries, and left four untouched three levels below (#138).
+    for base, _dirs, names in os.walk(root):
+        for name in names:
+            if not name.endswith('.json'):
+                continue
+            path = os.path.join(base, name)
+            files += 1
+            for page_num, title, value in _entries(path):
+                where = '%s  page %s "%s"' % (os.path.relpath(path, content_dir),
+                                              page_num, title)
+                if '\\' in value:
+                    separator.append('%s\n      -> %s' % (where, value))
+                    continue
+                if not os.path.exists(os.path.join(root, value)):
+                    missing.append('%s\n      -> %s' % (where, value))
+
+    print('Checked %d JSON files under %s\n' % (files, root))
+    for label, hits in (('Windows separators (invisible off Windows)', separator),
+                        ('Sub-directories that do not exist', missing)):
+        if hits:
+            print('%s: %d' % (label, len(hits)))
+            for h in hits:
+                print('   %s' % h)
+            print()
+    if not separator and not missing:
+        print('No unreachable sub-directories found.')
+        return 0
+    print('Each entry above is a branch of the service that is currently '
+          'unreachable.\nThe files are still on disk; only the reference is '
+          'broken.')
+    return 1
+
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        target = sys.argv[1]
+    else:
+        target = os.environ.get('COMPUNET_CONTENT_DIR') or os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), 'data', 'content')
+    sys.exit(check(target))

--- a/server/compunet_server.py
+++ b/server/compunet_server.py
@@ -631,10 +631,31 @@ class CompunetDirectory:
         slug = re.sub(r'[^a-z0-9\-]', '', slug)
         return slug.strip('-') or 'untitled'
 
+    @staticmethod
+    def _resolve_content_path(rel):
+        """Resolve a `directory` value against ROOT_DIR, whatever wrote it.
+
+        ⚠ A SUB-DIRECTORY RECORDED WITH A WINDOWS SEPARATOR IS INVISIBLE HERE.
+        `os.path.join(root, 'jungle\\directory.json')` on POSIX yields a path
+        whose last component is the literal string `jungle\directory.json`, and
+        nothing on disk matches it — so the entire sub-tree silently vanishes
+        from the service while its files sit there.
+
+        The tree WRITER has normalised to forward slashes since it learned this
+        ($_save_directory: "those do not resolve on the Linux host that actually
+        serves this tree"), but the reader did not, which left every tree
+        written before that fix quietly broken (#141). The tracked test fixture
+        was one of them and nobody noticed for months (#138).
+
+        `/` is not legal in a Windows filename, so rewriting the separator can
+        never corrupt a name that was legitimate.
+        """
+        return os.path.join(ROOT_DIR, rel.replace('\\', '/'))
+
     def _build_flat_page(self, node, parent, base_dir):
         """Build a page from flat JSON node, resolving paths from its folder."""
         if 'directory' in node:
-            dir_json_path = os.path.join(ROOT_DIR, node['directory'])
+            dir_json_path = self._resolve_content_path(node['directory'])
             page_dir = os.path.dirname(dir_json_path)
         else:
             page_slug = self._make_slug(node['title'])
@@ -682,8 +703,21 @@ class CompunetDirectory:
 
         # If page is also a directory, load sub-directory JSON
         if 'directory' in node:
-            dir_json_path = os.path.join(ROOT_DIR, node['directory'])
+            dir_json_path = self._resolve_content_path(node['directory'])
             sub_base_dir = os.path.dirname(dir_json_path)
+            # ⚠ SAY SO when it does not resolve. This branch used to have no
+            # `else`: a sub-directory that could not be found was skipped in
+            # silence, so an entire branch of the service disappeared and the
+            # only symptom was a listing that was simply shorter than it should
+            # be — nothing to correlate against. A missing FRAME has warned
+            # since forever, one code path below; a missing sub-directory costs
+            # far more and said nothing (#141).
+            if not os.path.exists(dir_json_path):
+                log.warning('CONTENT: page %s "%s" points at a sub-directory '
+                            'that does not exist: %s (from %r) — everything '
+                            'below it is unreachable',
+                            node.get('page_num'), node.get('title'),
+                            dir_json_path, node['directory'])
             if os.path.exists(dir_json_path):
                 with open(dir_json_path, 'r') as f:
                     sub_data = json.load(f)

--- a/server/data.example/content/root/jungle/directory.json
+++ b/server/data.example/content/root/jungle/directory.json
@@ -27,8 +27,7 @@
       "author": "JUNGLE",
       "price": 0,
       "life": 30,
-      "frames": ["frame-1.seq"],
-      "directory": "jungle/graphics/directory.json"
+      "frames": ["frame-1.seq"]
     },
     {
       "page_num": 602,
@@ -37,8 +36,7 @@
       "author": "JUNGLE",
       "price": 0,
       "life": 30,
-      "frames": ["frame-1.seq"],
-      "directory": "jungle/music/directory.json"
+      "frames": ["frame-1.seq"]
     },
     {
       "page_num": 603,
@@ -56,8 +54,7 @@
       "author": "JUNGLE",
       "price": 0,
       "life": 30,
-      "frames": ["frame-1.seq"],
-      "directory": "jungle/demos/directory.json"
+      "frames": ["frame-1.seq"]
     },
     {
       "page_num": 612,

--- a/server/tests/test_tree.py
+++ b/server/tests/test_tree.py
@@ -76,6 +76,88 @@ class TheShippedTreesHaveUniquePageNumbers(unittest.TestCase):
                          'entries not reachable by their own page number')
 
 
+class AWindowsWrittenTreeStillLoads(unittest.TestCase):
+    """The reader must accept what older writers produced (#141).
+
+    ⚠ The tracked trees are clean and `TheShippedTreesUsePortablePaths` keeps
+    them that way — but that guards the FIXTURES, not the trees already on disk
+    elsewhere. The writer only started normalising separators after the problem
+    was found, so every tree written before that still records its children as
+    `jungle\\directory.json`, and on this host `os.path.join` turns that into a
+    filename nothing matches. The sub-tree then vanishes from the service with
+    its files intact.
+
+    So this builds the broken shape deliberately, which is the only way it can
+    now occur, and asserts the reader copes.
+    """
+
+    def setUp(self):
+        import shutil
+        import tempfile
+        self._tmp = tempfile.mkdtemp(prefix='compunet-winpath-')
+        shutil.copytree(os.path.join(_SERVER, 'data', 'content.test', 'root'),
+                        os.path.join(self._tmp, 'root'))
+        self._saved_root = srv.ROOT_DIR
+        srv.ROOT_DIR = os.path.join(self._tmp, 'root')
+
+    def tearDown(self):
+        import shutil
+        srv.ROOT_DIR = self._saved_root
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _rewrite(self, rel, replacements):
+        path = os.path.join(srv.ROOT_DIR, *rel)
+        with open(path) as f:
+            text = f.read()
+        for old, new in replacements:
+            self.assertIn(old, text, 'fixture no longer contains %r' % old)
+            text = text.replace(old, new)
+        with open(path, 'w') as f:
+            f.write(text)
+
+    def test_the_pages_inside_a_backslash_path_are_still_reachable(self):
+        """⚠ Assert the CONTENTS, not the entry.
+
+        THE ZOO itself survives a broken path — the loader builds the page from
+        the parent's node, so it is still listed and still addressable. What
+        disappears is everything the sub-directory JSON holds, which is the part
+        a user would go looking for. An assertion on `THE_ZOO in d.pages` passes
+        with the bug fully present, and that is worth stating: it is the exact
+        shape of test that let this survive.
+        """
+        self._rewrite(('jungle', 'directory.json'),
+                      [('"jungle/the-zoo/directory.json"',
+                        '"jungle\\\\the-zoo\\\\directory.json"')])
+        d = tree()
+        self.assertIn(THE_ZOO, d.pages, 'THE ZOO itself should never be lost')
+        for page_num, title in ((701, 'MARCH'), (714, 'JULY'), (721, 'ZOO INTERVIEW')):
+            self.assertIn(page_num, d.pages,
+                          '%s (%d) lost to a Windows separator' % (title, page_num))
+
+    def test_the_sub_trees_own_children_survive_too(self):
+        """Normalising only the top level would leave the same hole one level
+        down — which is exactly how the fixture sweep went wrong (#138)."""
+        self._rewrite(('jungle', 'directory.json'),
+                      [('"jungle/the-zoo/directory.json"',
+                        '"jungle\\\\the-zoo\\\\directory.json"')])
+        d = tree()
+        zoo = d.pages[THE_ZOO]
+        self.assertTrue(zoo.children, 'THE ZOO loaded but lost its own children')
+
+    def test_an_unresolvable_sub_directory_is_reported(self):
+        """⚠ The other half, and the reason this went unnoticed for so long:
+        the loader skipped a sub-directory it could not find WITHOUT SAYING SO.
+        The only symptom was a listing that was shorter than it should be."""
+        self._rewrite(('jungle', 'directory.json'),
+                      [('"jungle/the-zoo/directory.json"',
+                        '"jungle/nowhere-at-all/directory.json"')])
+        with self.assertLogs('compunet', level='WARNING') as captured:
+            tree()
+        blob = '\n'.join(captured.output)
+        self.assertIn('nowhere-at-all', blob, 'the broken path is not named')
+        self.assertIn(str(THE_ZOO), blob, 'the page it belongs to is not named')
+
+
 class TheShippedTreesUsePortablePaths(unittest.TestCase):
     """A sub-directory recorded with a Windows separator is INVISIBLE on the
     host that serves this tree.
@@ -94,7 +176,13 @@ class TheShippedTreesUsePortablePaths(unittest.TestCase):
     stops where the bug was last seen is not a guard.
     """
 
-    TREES = ('data/content.test', 'data.example')
+    # ⚠ `data.example` holds its tree under `content/`, not at its own root.
+    # The first version of this named the directory itself, so the existence
+    # check below hit `if not os.path.isdir(...): continue` and skipped the
+    # whole tree in silence — a guard quietly guarding nothing, which is the
+    # very shape of bug it was written to catch. It was hiding three dangling
+    # entries (GRAPHICS, MUSIC and DEMOS).
+    TREES = ('data/content.test', 'data.example/content')
 
     def test_no_sub_directory_path_uses_a_windows_separator(self):
         offenders = []
@@ -126,8 +214,8 @@ class TheShippedTreesUsePortablePaths(unittest.TestCase):
         for rel in self.TREES:
             root = os.path.join(_SERVER, rel)
             content_root = os.path.join(root, 'root')
-            if not os.path.isdir(content_root):
-                continue
+            self.assertTrue(os.path.isdir(content_root),
+                            'no tree at %s — this guard would silently pass' % content_root)
             for base, _dirs, files in os.walk(content_root):
                 for name in files:
                     if name != 'directory.json' and name != 'root.json':


### PR DESCRIPTION
Closes #141.

## The fault

The tree **writer** has normalised separators to forward slashes since it learned that backslashes *"do not resolve on the Linux host that actually serves this tree"*. The **reader** never did.

So a tree written before that fix still records its children as `jungle\directory.json`, and on the host serving it `os.path.join` produces a filename nothing matches. The sub-tree disappears from the service with every one of its files intact on disk.

And it disappeared **in silence** — the loader guarded with `if os.path.exists(...)` and had no `else`. The only symptom was a listing shorter than it should be, with nothing to correlate against. A missing *frame* has warned since forever, one code path below; a missing sub-directory costs a whole branch and said nothing.

## The fix

- `_resolve_content_path()` accepts either separator. `/` is not legal in a Windows filename, so the rewrite cannot corrupt a name that was ever legitimate.
- An entry that does not resolve is logged with the **page number and title** that own it, matching the existing frame warning.

## Checking a live tree

`server/check_content_tree.py` — read-only, stdlib only, non-zero exit on findings:

```
python3 server/check_content_tree.py [CONTENT_DIR]
```

With no argument it resolves `$COMPUNET_CONTENT_DIR` exactly as the server does, so run with the service's own environment and it checks the tree actually being served. It reports both faults: Windows separators, and entries that resolve but point nowhere.

It exists because the reader fix only helps once the server restarts — and because the live tree could not be inspected at all from here (`vme.compunet.live` answers on none of 22, 443 or 2222 from this network). Dropping this on the host answers the question without needing that.

## What it found immediately

Run against the shipped trees, it flagged **three dangling entries in `data.example`** — `GRAPHICS`, `MUSIC` and `DEMOS` each declared a `directory.json` that was never in the tree. They are otherwise identical to `GAMES`, which has no such key and works, so the key is spurious and is removed. An operator starting from `data.example` got three empty branches and no indication why.

## ⚠ And a hole in the guard from #140

That guard listed `data.example` as a tree to check — but `data.example` holds its content under `content/`, so the existence half hit `if not os.path.isdir(...): continue` and **skipped the entire tree in silence**. A guard quietly guarding nothing, which is exactly the shape of bug it was written to catch, and it was hiding those three entries.

It now names the right path and *asserts* the tree is present rather than skipping when it is not.

## Tests

Three in `test_tree.py`, each verified to **fail** with its half of the fix removed:

- the pages inside a backslash path are still reachable — asserting the **contents**, not the entry, because the entry survives the bug and an assertion on it passes with the fault fully present
- their own children survive one level further down
- an unresolvable entry is reported, named by page number

All seven server suites pass.

## Still outstanding

`DEMOS` in `data.example` has no folder at all, so its declared `frames: ["frame-1.seq"]` is missing too. That is a content gap rather than a path fault, the checker does not cover frames, and I have not invented content to fill it.
